### PR TITLE
feat: add support for newlines replacement

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,16 @@
           "type": "boolean",
           "default": false,
           "description": "If selected, the code macro's content will be collapsed upon visiting or refreshing the Confluence page"
+        },
+        "md2confl.replaceNewLinesInParagraphs": {
+          "type": "boolean",
+          "default": false,
+          "description": "If selected, newline characters (\\n or \\r\\n) will be replaced by spaces or by a string"
+        },
+        "md2confl.replaceNewLinesInParagraphsWithString": {
+          "type": "string",
+          "default": "",
+          "description": "String to be used to replace newline characters inside paragraph"
         }
       }
     }

--- a/src/confluenceRenderer.ts
+++ b/src/confluenceRenderer.ts
@@ -50,6 +50,7 @@ export type MarkdownToAtlassianWikiMarkupOptions = {
       | boolean
       | ((code: string, lang: AtlassianSupportLanguage) => boolean);
   };
+  replaceNewLinesInParagraphs?: boolean | string;
 };
 
 type ListHeadCharacter = {
@@ -73,6 +74,18 @@ const TableCellTypeCharacter: TableCellTypeCharacter = {
 const confluenceListRegExp = new RegExp(
   `^(${Object.values(ListHeadCharacter).map(escapeStringRegexp).join("|")})`
 );
+
+const replaceSingleNewlineWithSpace = (
+  text: string,
+  rendererOptions: MarkdownToAtlassianWikiMarkupOptions | undefined
+): string => {
+  const replaceNewLinesInParagraphs =
+    rendererOptions?.replaceNewLinesInParagraphs || false;
+  if (replaceNewLinesInParagraphs === false) return text;
+  const replacementText =
+    replaceNewLinesInParagraphs === true ? " " : replaceNewLinesInParagraphs;
+  return text.replace(/((\r)?\n)/g, replacementText).trim();
+};
 
 const unescapeHtmlSpecialCharacteres = (text: string): string => {
   return text.replace(
@@ -121,7 +134,11 @@ export class AtlassianWikiMarkupRenderer extends Renderer {
   }
 
   public paragraph(text: string): string {
-    const unescapedText = unescapeHtmlSpecialCharacteres(text);
+    const replacedText = replaceSingleNewlineWithSpace(
+      text,
+      this.rendererOptions
+    );
+    const unescapedText = unescapeHtmlSpecialCharacteres(replacedText);
     return `${unescapedText}\n\n`;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -61,12 +61,17 @@ function getActiveText(): string {
       true
     );
     const collapse: boolean = myConfig.get("codeBlock.collapse", false);
+    const replaceNewLinesInParagraphs: boolean = myConfig.get("replaceNewLinesInParagraphs", false);
+    const replaceNewLinesInParagraphsWithString: string = myConfig.get("replaceNewLinesInParagraphsWithString", "");
     const options: MarkdownToAtlassianWikiMarkupOptions = {
       codeBlock: {
         theme: theme,
         showLineNumbers: showLineNumbers,
         collapse: collapse,
       },
+      replaceNewLinesInParagraphs: replaceNewLinesInParagraphs ? 
+        (!replaceNewLinesInParagraphsWithString ? true : replaceNewLinesInParagraphsWithString) :
+        false
     };
     const wikiMarkup = markdownToAtlassianWikiMarkup(content, options);
 


### PR DESCRIPTION
Dear Maintainer,

This PR adds support to replacing newline characters in the body of a paragraph with single spaces, or, if specified, with a dedicated character.

This is necessary because single newlines are not rendered in markdown, while they are rendered in Atlassian Confluence Markup.

For compatibility reasons, this feature is hidden behind a configuration option.